### PR TITLE
feat(payments): add stripe payment endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@nestjs/platform-express": "^11.0.0",
         "axios": "^1.11.0",
         "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.8.0"
+        "rxjs": "^7.8.0",
+        "stripe": "^12.18.0"
       },
       "devDependencies": {
         "@nestjs/schematics": "^11.0.0",
@@ -4587,7 +4588,6 @@
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
       "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -14454,6 +14454,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
+      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/strtok3": {
       "version": "10.3.4",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
@@ -15270,7 +15283,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "axios": "^1.11.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.0"
+    "rxjs": "^7.8.0",
+    "stripe": "^12.18.0"
   }
 }

--- a/payments/src/app/app.controller.ts
+++ b/payments/src/app/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Headers, Post } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
@@ -8,5 +8,24 @@ export class AppController {
   @Get()
   getMessage(): string {
     return this.appService.getMessage();
+  }
+
+  @Post('charge')
+  createCharge(
+    @Body('amount') amount: number,
+    @Body('source') source: string,
+    @Body('currency') currency: string,
+  ) {
+    return this.appService.createCharge(amount, source, currency);
+  }
+
+  @Post('webhook')
+  handleWebhook(
+    @Headers('stripe-signature') signature: string,
+    @Body() body: any,
+  ) {
+    const payload = Buffer.from(JSON.stringify(body));
+    this.appService.handleWebhook(signature, payload);
+    return { received: true };
   }
 }

--- a/payments/src/app/app.service.spec.ts
+++ b/payments/src/app/app.service.spec.ts
@@ -17,4 +17,40 @@ describe('AppService', () => {
       expect(service.getMessage()).toEqual('Payments service');
     });
   });
+
+  describe('createCharge', () => {
+    it('should create a charge successfully', async () => {
+      const stripeMock = {
+        charges: {
+          create: jest
+            .fn()
+            .mockResolvedValue({ id: 'ch_1', status: 'succeeded' }),
+        },
+        webhooks: { constructEvent: jest.fn() },
+      } as any;
+
+      (service as any).stripe = stripeMock;
+
+      await expect(
+        service.createCharge(1000, 'tok_visa', 'usd')
+      ).resolves.toEqual({ id: 'ch_1', status: 'succeeded' });
+    });
+
+    it('should throw an error when payment fails', async () => {
+      const stripeMock = {
+        charges: {
+          create: jest
+            .fn()
+            .mockRejectedValue(new Error('card declined')),
+        },
+        webhooks: { constructEvent: jest.fn() },
+      } as any;
+
+      (service as any).stripe = stripeMock;
+
+      await expect(
+        service.createCharge(1000, 'tok_fail', 'usd')
+      ).rejects.toThrow('Payment failed');
+    });
+  });
 });

--- a/payments/src/app/app.service.ts
+++ b/payments/src/app/app.service.ts
@@ -1,8 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import Stripe from 'stripe';
 
 @Injectable()
 export class AppService {
+  private stripe: Stripe;
+
+  constructor() {
+    this.stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? 'sk_test', {
+      apiVersion: '2022-11-15',
+    });
+  }
+
   getMessage(): string {
     return 'Payments service';
+  }
+
+  async createCharge(
+    amount: number,
+    source: string,
+    currency = 'usd'
+  ): Promise<Stripe.Charge> {
+    try {
+      return await this.stripe.charges.create({ amount, currency, source });
+    } catch (error) {
+      throw new Error('Payment failed');
+    }
+  }
+
+  handleWebhook(signature: string, payload: Buffer): Stripe.Event {
+    return this.stripe.webhooks.constructEvent(
+      payload,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET ?? 'whsec_test'
+    );
   }
 }


### PR DESCRIPTION
## Summary
- integrate Stripe SDK for payment processing
- add charge creation and webhook endpoints
- test successful and failed charges

## Testing
- `CI=true npx jest payments/src/app/app.service.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_688f8c3debcc83319e8c970c00b79105